### PR TITLE
refactor(script): replace raw class numbers with enum values

### DIFF
--- a/src/game/actor_corpse.cpp
+++ b/src/game/actor_corpse.cpp
@@ -828,7 +828,7 @@ int __cdecl Actor_BecomeCorpse(gentity_s *self)
     v15->tree = v17;
     v15->entnum = self->s.number;
     Scr_Notify(self, death, 0);
-    Scr_FreeEntityNum(self->s.number, 0);
+    Scr_FreeEntityNum(self->s.number, CLASS_NUM_ENTITY);
     G_DObjUpdate(self);
     v20 = &g_scr_data.actorCorpseInfo[FreeActorCorpseIndex].proneInfo;
     v21 = (unsigned int*)v25;

--- a/src/game/actor_fields.cpp
+++ b/src/game/actor_fields.cpp
@@ -1224,7 +1224,7 @@ void __cdecl GScr_AddFieldsForActor()
         iassert(!((f - aifields) & ENTFIELD_MASK));
         iassert((f - aifields) == (unsigned short)(f - aifields));
 
-        Scr_AddClassField(0, (char*)f->name, (unsigned __int16)(f - aifields) | ENTFIELD_ACTOR);
+        Scr_AddClassField(CLASS_NUM_ENTITY, (char*)f->name, (unsigned __int16)(f - aifields) | ENTFIELD_ACTOR);
     }
 }
 

--- a/src/game/g_client_fields.cpp
+++ b/src/game/g_client_fields.cpp
@@ -406,7 +406,7 @@ void __cdecl GScr_AddFieldsForClient()
             MyAssertHandler(".\\game\\g_client_fields.cpp", 478, 0, "%s", "!((f - fields) & ENTFIELD_MASK)");
         if (f - fields != (uint16_t)(f - fields))
             MyAssertHandler(".\\game\\g_client_fields.cpp", 479, 0, "%s", "(f - fields) == (unsigned short)( f - fields )");
-        Scr_AddClassField(0, (char *)f->name, (uint16_t)(f - fields) | 0xC000);
+        Scr_AddClassField(CLASS_NUM_ENTITY, (char *)f->name, (uint16_t)(f - fields) | 0xC000);
     }
 #endif
 }

--- a/src/game/g_hudelem.cpp
+++ b/src/game/g_hudelem.cpp
@@ -679,7 +679,7 @@ void __cdecl HECmd_SetText(scr_entref_t entref)
 
 game_hudelem_s *__cdecl HECmd_GetHudElem(scr_entref_t entref)
 {
-    if (entref.classnum == 1)
+    if (entref.classnum == CLASS_NUM_HUDELEM)
     {
         if (entref.entnum >= MAX_HUDELEMS_TOTAL)
             MyAssertHandler(".\\game\\g_hudelem.cpp", 832, 0, "%s", "entref.entnum < ARRAY_COUNT( g_hudelems )");

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -255,7 +255,7 @@ void __cdecl G_DuplicateScriptFields(gentity_s *dest, const gentity_s *source)
 {
     iassert(dest->s.number == dest - g_entities);
     iassert(source->s.number == source - g_entities);
-    Scr_CopyEntityNum(source->s.number, dest->s.number, 0);
+    Scr_CopyEntityNum(source->s.number, dest->s.number, CLASS_NUM_ENTITY);
 }
 
 const gitem_s *__cdecl G_GetItemForClassname(const char *classname, unsigned __int8 model)
@@ -360,7 +360,7 @@ void __cdecl GScr_AddFieldsForEntity()
         iassert(((f - fields_1) & ENTFIELD_MASK) == ENTFIELD_ENTITY);
         iassert((f - fields_1) == (unsigned short)(f - fields_1));
 
-        Scr_AddClassField(0, (char*)f->name, (unsigned __int16)(f - fields_1));
+        Scr_AddClassField(CLASS_NUM_ENTITY, (char*)f->name, (unsigned __int16)(f - fields_1));
     }
 
     GScr_AddFieldsForActor();
@@ -397,7 +397,7 @@ void __cdecl Scr_FreeEntity(gentity_s *ent)
             "(ent->r.inuse)",
             ent->s.number);
     Scr_FreeEntityFields(ent);
-    Scr_FreeEntityNum(ent->s.number, 0);
+    Scr_FreeEntityNum(ent->s.number, CLASS_NUM_ENTITY);
 }
 
 void __cdecl Scr_AddEntity(gentity_s *ent)
@@ -423,7 +423,7 @@ void __cdecl Scr_AddEntity(gentity_s *ent)
             "%s\n\t(ent->s.number) = %i",
             "(ent->r.inuse)",
             ent->s.number);
-    Scr_AddEntityNum(ent->s.number, 0);
+    Scr_AddEntityNum(ent->s.number, CLASS_NUM_ENTITY);
 }
 
 gentity_s *__cdecl Scr_GetEntityAllowNull(unsigned int index)
@@ -465,9 +465,9 @@ void __cdecl Scr_FreeHudElem(game_hudelem_s *hud)
     bcassert(hud - g_hudelems, MAX_HUDELEMS_TOTAL);
     iassert(hud->elem.type != HE_TYPE_FREE);
 
-    Scr_NotifyNum(hudIndex, 1u, scr_const.death, 0);
+    Scr_NotifyNum(hudIndex, CLASS_NUM_HUDELEM, scr_const.death, 0);
     Scr_FreeHudElemConstStrings(hud);
-    Scr_FreeEntityNum(hudIndex, 1u);
+    Scr_FreeEntityNum(hudIndex, CLASS_NUM_HUDELEM);
 }
 
 void __cdecl Scr_AddHudElem(game_hudelem_s *hud)
@@ -487,7 +487,7 @@ void __cdecl Scr_AddHudElem(game_hudelem_s *hud)
             256);
     if (hud->elem.type == HE_TYPE_FREE)
         MyAssertHandler("c:\\trees\\cod3\\cod3src\\src\\game\\g_spawn.cpp", 936, 0, "%s", "hud->elem.type != HE_TYPE_FREE");
-    Scr_AddEntityNum(v2, 1u);
+    Scr_AddEntityNum(v2, CLASS_NUM_HUDELEM);
 }
 
 game_hudelem_s *__cdecl Scr_GetHudElem(unsigned int index)
@@ -495,7 +495,7 @@ game_hudelem_s *__cdecl Scr_GetHudElem(unsigned int index)
     scr_entref_t entref; // [sp+50h] [-20h]
 
     entref = Scr_GetEntityRef(index);
-    if (entref.classnum == 1)
+    if (entref.classnum == CLASS_NUM_HUDELEM)
     {
         iassert(entref.entnum < MAX_HUDELEMS_TOTAL);
         return &g_hudelems[entref.entnum];
@@ -530,7 +530,7 @@ int __cdecl Scr_ExecEntThread(gentity_s *ent, int handle, unsigned int paramcoun
             "%s\n\t(ent->s.number) = %i",
             "(ent->r.inuse)",
             ent->s.number);
-    return Scr_ExecEntThreadNum(ent->s.number, 0, handle, paramcount);
+    return Scr_ExecEntThreadNum(ent->s.number, CLASS_NUM_ENTITY, handle, paramcount);
 }
 
 void __cdecl Scr_AddExecEntThread(gentity_s *ent, int handle, unsigned int paramcount)
@@ -556,7 +556,7 @@ void __cdecl Scr_AddExecEntThread(gentity_s *ent, int handle, unsigned int param
             "%s\n\t(ent->s.number) = %i",
             "(ent->r.inuse)",
             ent->s.number);
-    Scr_AddExecEntThreadNum(ent->s.number, 0, handle, paramcount);
+    Scr_AddExecEntThreadNum(ent->s.number, CLASS_NUM_ENTITY, handle, paramcount);
 }
 
 void __cdecl Scr_Notify(gentity_s *ent, unsigned __int16 stringValue, unsigned int paramcount)
@@ -586,7 +586,7 @@ void __cdecl Scr_Notify(gentity_s *ent, unsigned __int16 stringValue, unsigned i
             "%s\n\t(ent->s.number) = %i",
             "(ent->r.inuse)",
             ent->s.number);
-    Scr_NotifyNum(ent->s.number, 0, stringValue, paramcount);
+    Scr_NotifyNum(ent->s.number, CLASS_NUM_ENTITY, stringValue, paramcount);
 }
 
 void __cdecl Scr_GetGenericEnt(unsigned int offset, unsigned int name)
@@ -1298,18 +1298,18 @@ int __cdecl Scr_SetObjectField(unsigned int classnum, unsigned int entnum, int o
 
     switch (classnum)
     {
-    case 0u:
+    case CLASS_NUM_ENTITY:
         result = Scr_SetEntityField(entnum, offset);
         break;
-    case 1u:
+    case CLASS_NUM_HUDELEM:
         Scr_SetHudElemField(entnum, offset);
         result = 1;
         break;
-    case 2u:
+    case CLASS_NUM_PATHNODE:
         Scr_SetPathnodeField(entnum, offset);
         result = 1;
         break;
-    case 3u:
+    case CLASS_NUM_VEHICLENODE:
         v4 = va("vehicle node is read-only", offset);
         Scr_Error(v4);
         result = 1;
@@ -1397,16 +1397,16 @@ void __cdecl Scr_GetObjectField(unsigned int classnum, unsigned int entnum, unsi
 
     switch (classnum)
     {
-    case 0u:
+    case CLASS_NUM_ENTITY:
         Scr_GetEntityField(entnum, offset);
         break;
-    case 1u:
+    case CLASS_NUM_HUDELEM:
         Scr_GetHudElemField(entnum, offset);
         break;
-    case 2u:
+    case CLASS_NUM_PATHNODE:
         Scr_GetPathnodeField(entnum, offset);
         break;
-    case 3u:
+    case CLASS_NUM_VEHICLENODE:
         GScr_GetVehicleNodeField(entnum, offset);
         break;
     default:

--- a/src/game/g_vehicle_path.cpp
+++ b/src/game/g_vehicle_path.cpp
@@ -902,7 +902,7 @@ void __cdecl G_FreeVehiclePaths()
         do
         {
             v1 = &s_nodes[v0];
-            Scr_FreeEntityNum(v1->index, 3u);
+            Scr_FreeEntityNum(v1->index, CLASS_NUM_VEHICLENODE);
             Scr_SetString(&v1->name, 0);
             Scr_SetString(&v1->target, 0);
             Scr_SetString(&v1->script_linkname, 0);
@@ -922,7 +922,7 @@ void __cdecl G_FreeVehiclePathsScriptInfo()
         v0 = 0;
         do
         {
-            Scr_FreeEntityNum(s_nodes[v0].index, 3u);
+            Scr_FreeEntityNum(s_nodes[v0].index, CLASS_NUM_VEHICLENODE);
             v0 = (__int16)(v0 + 1);
         } while (v0 < s_numNodes);
     }
@@ -1338,7 +1338,7 @@ int __cdecl GScr_GetVehicleNodeIndex(int index)
     scr_entref_t EntityRef; // [sp+50h] [-20h]
 
     EntityRef = Scr_GetEntityRef(index);
-    if (EntityRef.classnum == 3)
+    if (EntityRef.classnum == CLASS_NUM_VEHICLENODE)
     {
         if (EntityRef.entnum >= s_numNodes)
             MyAssertHandler(
@@ -1454,7 +1454,7 @@ void __cdecl GScr_GetVehicleNode()
                 v7 = (__int16)(v7 + 1);
             } while (v7 < v6);
             if (v5)
-                Scr_AddEntityNum(v5->index, 3u);
+                Scr_AddEntityNum(v5->index, CLASS_NUM_VEHICLENODE);
         }
     }
 }
@@ -1499,7 +1499,7 @@ void __cdecl GScr_GetVehicleNodeArray()
                 {
                     if (*(unsigned __int16 *)((char *)&v7->name + v4->ofs) == ConstString)
                     {
-                        Scr_AddEntityNum(v7->index, 3u);
+                        Scr_AddEntityNum(v7->index, CLASS_NUM_VEHICLENODE);
                         Scr_AddArray();
                         v6 = s_numNodes;
                     }
@@ -1521,7 +1521,7 @@ void __cdecl GScr_GetAllVehicleNodes()
         v0 = 0;
         do
         {
-            Scr_AddEntityNum(s_nodes[v0].index, 3u);
+            Scr_AddEntityNum(s_nodes[v0].index, CLASS_NUM_VEHICLENODE);
             Scr_AddArray();
             v0 = (__int16)(v0 + 1);
         } while (v0 < s_numNodes);

--- a/src/game/pathnode.cpp
+++ b/src/game/pathnode.cpp
@@ -406,7 +406,7 @@ void __cdecl GScr_AddFieldsForPathnode()
     for (node_field_t *f = fields_3; f->name; ++f)
     {
         iassert((f - fields_3) == (unsigned short)(f - fields_3));
-        Scr_AddClassField(2, (char *)f->name, (unsigned __int16)(f - fields_3));
+        Scr_AddClassField(CLASS_NUM_PATHNODE, (char *)f->name, (unsigned __int16)(f - fields_3));
     }
 }
 
@@ -416,7 +416,7 @@ pathnode_t *__cdecl Scr_GetPathnode(unsigned int index)
 
     entref = Scr_GetEntityRef(index);
 
-    if (entref.classnum == 2)
+    if (entref.classnum == CLASS_NUM_PATHNODE)
     {
         bcassert(entref.entnum, g_path.actualNodeCount);
 
@@ -440,7 +440,7 @@ void __cdecl G_FreePathnodesScriptInfo()
         do
         {
             iassert(!gameWorldSp.path.nodes[nodeIndex].dynamic.pOwner.isDefined());
-            Scr_FreeEntityNum(nodeIndex++, 2);
+            Scr_FreeEntityNum(nodeIndex++, CLASS_NUM_PATHNODE);
         } while (nodeIndex < g_path.actualNodeCount);
     }
 }
@@ -3060,7 +3060,7 @@ void __cdecl Scr_FreePathnode(pathnode_t *node)
 {
     iassert(!node->dynamic.pOwner.isDefined());
 
-    Scr_FreeEntityNum(Path_ConvertNodeToIndex(node), 2u);
+    Scr_FreeEntityNum(Path_ConvertNodeToIndex(node), CLASS_NUM_PATHNODE);
 }
 
 void __cdecl Scr_AddPathnode(pathnode_t *node)
@@ -3068,7 +3068,7 @@ void __cdecl Scr_AddPathnode(pathnode_t *node)
     unsigned int v1; // r3
 
     v1 = Path_ConvertNodeToIndex(node);
-    Scr_AddEntityNum(v1, 2u);
+    Scr_AddEntityNum(v1, CLASS_NUM_PATHNODE);
 }
 
 void __cdecl Scr_GetNode()
@@ -3125,7 +3125,7 @@ void __cdecl Scr_GetNode()
             if (v5)
             {
                 v9 = Path_ConvertNodeToIndex(v5);
-                Scr_AddEntityNum(v9, 2u);
+                Scr_AddEntityNum(v9, CLASS_NUM_PATHNODE);
             }
         }
     }
@@ -3175,7 +3175,7 @@ void __cdecl Scr_GetNodeArray()
                 if (*(unsigned __int16 *)((char *)&v7->constant.type + v4->ofs) == ConstString)
                 {
                     v8 = Path_ConvertNodeToIndex(v7);
-                    Scr_AddEntityNum(v8, 2u);
+                    Scr_AddEntityNum(v8, CLASS_NUM_PATHNODE);
                     Scr_AddArray();
                     nodes = gameWorldSp.path.nodes;
                     actualNodeCount = g_path.actualNodeCount;
@@ -3200,7 +3200,7 @@ void __cdecl Scr_GetAllNodes()
         do
         {
             v2 = Path_ConvertNodeToIndex(&gameWorldSp.path.nodes[v1]);
-            Scr_AddEntityNum(v2, 2u);
+            Scr_AddEntityNum(v2, CLASS_NUM_PATHNODE);
             Scr_AddArray();
             ++v0;
             ++v1;
@@ -3230,7 +3230,7 @@ void __cdecl Path_Shutdown()
     for (g_path.originErrors = 0; node != &gameWorldSp.path.nodes[g_path.actualNodeCount]; ++node)
     {
         iassert(!node->dynamic.pOwner.isDefined());
-        Scr_FreeEntityNum(Path_ConvertNodeToIndex(node), 2);
+        Scr_FreeEntityNum(Path_ConvertNodeToIndex(node), CLASS_NUM_PATHNODE);
     }
     g_path.actualNodeCount = 0;
     g_pPath = 0;

--- a/src/game/sentient_fields.cpp
+++ b/src/game/sentient_fields.cpp
@@ -115,7 +115,7 @@ void __cdecl GScr_AddFieldsForSentient()
         iassert(!((f - fields_2) & ENTFIELD_MASK));
         iassert((f - fields_2) == (unsigned short)(f - fields_2));
 
-        Scr_AddClassField(0, (char*)f->name, (unsigned __int16)(f - fields_2) | ENTFIELD_SENTIENT);
+        Scr_AddClassField(CLASS_NUM_ENTITY, (char*)f->name, (unsigned __int16)(f - fields_2) | ENTFIELD_SENTIENT);
     }
 
 }

--- a/src/game_mp/g_scr_main_mp.cpp
+++ b/src/game_mp/g_scr_main_mp.cpp
@@ -438,7 +438,7 @@ void GScr_PostLoadScripts()
 {
     int32_t classnum; // [esp+0h] [ebp-4h]
 
-    for (classnum = 0; classnum < 4; ++classnum)
+    for (classnum = 0; classnum < CLASS_NUM_COUNT; ++classnum)
         Scr_SetClassMap(classnum);
     GScr_AddFieldsForEntity();
     GScr_AddFieldsForHudElems();
@@ -449,7 +449,7 @@ void __cdecl GScr_FreeScripts()
 {
     int32_t classnum; // [esp+0h] [ebp-4h]
 
-    for (classnum = 0; classnum < 4; ++classnum)
+    for (classnum = 0; classnum < CLASS_NUM_COUNT; ++classnum)
         Scr_RemoveClassMap(classnum);
 }
 

--- a/src/game_mp/g_spawn_mp.cpp
+++ b/src/game_mp/g_spawn_mp.cpp
@@ -170,7 +170,7 @@ void __cdecl GScr_AddFieldsForEntity()
             MyAssertHandler(".\\game_mp\\g_spawn_mp.cpp", 531, 0, "%s", "((f - fields) & ENTFIELD_MASK) == ENTFIELD_ENTITY");
         if (f - fields_1 != (uint16_t)(f - fields_1))
             MyAssertHandler(".\\game_mp\\g_spawn_mp.cpp", 532, 0, "%s", "(f - fields) == (unsigned short)( f - fields )");
-        Scr_AddClassField(0, (char *)f->name, (uint16_t)(f - fields_1));
+        Scr_AddClassField(CLASS_NUM_ENTITY, (char *)f->name, (uint16_t)(f - fields_1));
     }
     GScr_AddFieldsForClient();
 }
@@ -224,9 +224,9 @@ int32_t __cdecl Scr_SetObjectField(uint32_t classnum, uint32_t entnum, uint32_t 
 {
     const char *v4; // eax
 
-    if (!classnum)
+    if (classnum == CLASS_NUM_ENTITY)
         return Scr_SetEntityField(entnum, offset);
-    if (classnum == 1)
+    if (classnum == CLASS_NUM_HUDELEM)
     {
         Scr_SetHudElemField(entnum, offset);
     }
@@ -385,7 +385,7 @@ void __cdecl Scr_FreeEntity(gentity_s *ent)
     if (!ent->r.inuse)
         MyAssertHandler(".\\game_mp\\g_spawn_mp.cpp", 805, 0, "%s\n\t(ent->s.number) = %i", "(ent->r.inuse)", ent->s.number);
     Scr_FreeEntityConstStrings(ent);
-    Scr_FreeEntityNum(ent->s.number, 0);
+    Scr_FreeEntityNum(ent->s.number, CLASS_NUM_ENTITY);
 }
 
 void __cdecl Scr_AddEntity(gentity_s *ent)
@@ -402,7 +402,7 @@ void __cdecl Scr_AddEntity(gentity_s *ent)
             ent - g_entities);
     if (!ent->r.inuse)
         MyAssertHandler(".\\game_mp\\g_spawn_mp.cpp", 821, 0, "%s\n\t(ent->s.number) = %i", "(ent->r.inuse)", ent->s.number);
-    Scr_AddEntityNum(ent->s.number, 0);
+    Scr_AddEntityNum(ent->s.number, CLASS_NUM_ENTITY);
 }
 
 gentity_s *__cdecl Scr_GetEntityAllowNull(uint32_t index)
@@ -451,9 +451,9 @@ void __cdecl Scr_FreeHudElem(game_hudelem_s *hud)
             1024);
     if (hud->elem.type == HE_TYPE_FREE)
         MyAssertHandler(".\\game_mp\\g_spawn_mp.cpp", 883, 0, "%s", "hud->elem.type != HE_TYPE_FREE");
-    Scr_NotifyNum(hud - g_hudelems, 1u, scr_const.death, 0);
+    Scr_NotifyNum(hud - g_hudelems, CLASS_NUM_HUDELEM, scr_const.death, 0);
     Scr_FreeHudElemConstStrings(hud);
-    Scr_FreeEntityNum(hud - g_hudelems, 1u);
+    Scr_FreeEntityNum(hud - g_hudelems, CLASS_NUM_HUDELEM);
 }
 
 void __cdecl Scr_AddHudElem(game_hudelem_s *hud)
@@ -470,7 +470,7 @@ void __cdecl Scr_AddHudElem(game_hudelem_s *hud)
             1024);
     if (hud->elem.type == HE_TYPE_FREE)
         MyAssertHandler(".\\game_mp\\g_spawn_mp.cpp", 904, 0, "%s", "hud->elem.type != HE_TYPE_FREE");
-    Scr_AddEntityNum(hud - g_hudelems, 1u);
+    Scr_AddEntityNum(hud - g_hudelems, CLASS_NUM_HUDELEM);
 }
 
 uint16_t __cdecl Scr_ExecEntThread(gentity_s *ent, int32_t handle, uint32_t paramcount)
@@ -487,7 +487,7 @@ uint16_t __cdecl Scr_ExecEntThread(gentity_s *ent, int32_t handle, uint32_t para
             ent - g_entities);
     if (!ent->r.inuse)
         MyAssertHandler(".\\game_mp\\g_spawn_mp.cpp", 939, 0, "%s\n\t(ent->s.number) = %i", "(ent->r.inuse)", ent->s.number);
-    return Scr_ExecEntThreadNum(ent->s.number, 0, handle, paramcount);
+    return Scr_ExecEntThreadNum(ent->s.number, CLASS_NUM_ENTITY, handle, paramcount);
 }
 
 void __cdecl Scr_Notify(gentity_s *ent, uint16_t stringValue, uint32_t paramcount)
@@ -496,7 +496,7 @@ void __cdecl Scr_Notify(gentity_s *ent, uint16_t stringValue, uint32_t paramcoun
     iassert(ent->s.number == ent - g_entities);
     iassert(ent->r.inuse);
 
-    Scr_NotifyNum(ent->s.number, 0, stringValue, paramcount);
+    Scr_NotifyNum(ent->s.number, CLASS_NUM_ENTITY, stringValue, paramcount);
 }
 
 void __cdecl Scr_GetEnt()
@@ -891,9 +891,9 @@ void __cdecl Scr_GetObjectField(uint32_t classnum, int entnum, int offset)
 {
     const char *v3; // eax
 
-    if (classnum)
+    if (classnum != CLASS_NUM_ENTITY)
     {
-        if (classnum == 1)
+        if (classnum == CLASS_NUM_HUDELEM)
         {
             Scr_GetHudElemField(entnum, offset);
         }

--- a/src/script/scr_variable.cpp
+++ b/src/script/scr_variable.cpp
@@ -22,7 +22,7 @@ scrVarDebugPub_t* scrVarDebugPub;
 scrVarDebugPub_t scrVarDebugPubBuf;
 scrVarGlob_t scrVarGlob;
 
-scr_classStruct_t g_classMap[4] =
+scr_classStruct_t g_classMap[CLASS_NUM_COUNT] =
 {
 	{ 0, 0, 0x65, "entity" },
 	{ 0, 0, 0x68, "hudelem" },
@@ -138,7 +138,7 @@ void Scr_InitVariableRange(uint32_t begin, uint32_t end)
 
 void Scr_InitClassMap()
 {
-	for (int classnum = 0; classnum < 4; ++classnum)
+	for (int classnum = 0; classnum < CLASS_NUM_COUNT; ++classnum)
 	{
 		g_classMap[classnum].entArrayId = 0;
 		g_classMap[classnum].id = 0;
@@ -1066,7 +1066,7 @@ int  Scr_GetClassnumForCharId(char charId)
 {
 	int i; // [esp+0h] [ebp-4h]
 
-	for (i = 0; i < 4; ++i)
+	for (i = 0; i < CLASS_NUM_COUNT; ++i)
 	{
 		if (g_classMap[i].charId == charId)
 			return i;
@@ -1491,7 +1491,7 @@ uint32_t  Scr_FindAllVariableField(uint32_t parentId, uint32_t* names)
 		goto $LN18_17;
 	case 0x14u:
 		classnum = parentValue->w.status >> 8;
-		if (classnum >= 4)
+		if (classnum >= CLASS_NUM_COUNT)
 			MyAssertHandler(".\\script\\scr_variable.cpp", 2558, 0, "%s", "classnum < CLASS_NUM_COUNT");
 		for (id = FindFirstSibling(g_classMap[classnum].id); id; id = FindNextSibling(id))
 		{
@@ -2455,7 +2455,7 @@ void Scr_DumpScriptThreads(void)
 			Com_Printf(23, "********************************\n");
 			Com_Printf(23, "var usage: %d, endon usage: %d\n", (int)varUsage, (int)endonUsage);
 			Com_Printf(23, "\n");
-			for (classnum = 0; classnum < 4; ++classnum)
+			for (classnum = 0; classnum < CLASS_NUM_COUNT; ++classnum)
 			{
 				if (g_classMap[classnum].entArrayId)
 				{

--- a/src/script/scr_variable.h
+++ b/src/script/scr_variable.h
@@ -55,7 +55,15 @@ enum var_stat_t
 
 #define FIRST_DEAD_OBJECT 0x16
 
-#define CLASS_NUM_COUNT 4
+enum scr_classnum_t
+{
+    CLASS_NUM_ENTITY      = 0x0,
+    CLASS_NUM_HUDELEM     = 0x1,
+    CLASS_NUM_PATHNODE    = 0x2,
+    CLASS_NUM_VEHICLENODE = 0x3,
+    CLASS_NUM_COUNT       = 0x4,
+};
+
 #define VAR_NAME_BITS 8
 #define VAR_NAME_LOW_MASK 0x00FFFFFF
 
@@ -235,7 +243,7 @@ struct scr_entref_t // sizeof=0x4
     scr_entref_t()
     {
         entnum = 0;
-        classnum = 0;
+        classnum = CLASS_NUM_ENTITY;
     }
     scr_entref_t(int i)
     {
@@ -505,7 +513,7 @@ uint32_t Scr_InitStringSet();
 void Scr_ShutdownStringSet(uint32_t setId);
 int Scr_AddStringSet(uint32_t setId, const char *string);
 
-extern scr_classStruct_t g_classMap[4];
+extern scr_classStruct_t g_classMap[CLASS_NUM_COUNT];
 extern scrStringDebugGlob_t *scrStringDebugGlob;
 extern scrMemTreePub_t scrMemTreePub;
 extern scrVarGlob_t scrVarGlob;;


### PR DESCRIPTION
Took the enum from the Xbox 360 debug PDB (`default_demo_mp`):
```c
/* 784 */
enum $63F7C8B7B63E2DF8CDE8AEDB77CF5EA5 : __int32
{
  CLASS_NUM_ENTITY = 0x0,
  CLASS_NUM_HUDELEM = 0x1,
  CLASS_NUM_PATHNODE = 0x2,
  CLASS_NUM_VEHICLENODE = 0x3,
  CLASS_NUM_COUNT = 0x4,
};
```

