### PR TITLE
Fixes & Updates

### DIFF
--- a/src/bgame/bg_jump.cpp
+++ b/src/bgame/bg_jump.cpp
@@ -28,7 +28,11 @@ void __cdecl Jump_RegisterDvars()
         mina,
         DVAR_CHEAT | DVAR_TEMP,
         "The maximum step up to the top of a jump arc");
+#ifdef KISAK_MP
     jump_slowdownEnable = Dvar_RegisterBool("jump_slowdownEnable", 1, DVAR_CHEAT | DVAR_TEMP, "Slow player movement after jumping");
+#elif KISAK_SP
+    jump_slowdownEnable = Dvar_RegisterBool("jump_slowdownEnable", 0, DVAR_CHEAT | DVAR_TEMP, "Slow player movement after jumping");
+#endif
     minb.value.max = 1024.0;
     minb.value.min = 0.0;
     jump_ladderPushVel = Dvar_RegisterFloat(

--- a/src/bgame/bg_misc.cpp
+++ b/src/bgame/bg_misc.cpp
@@ -459,6 +459,7 @@ void __cdecl BG_RegisterDvars()
         "The time interval before foliage sounds are reset after the player has stopped moving");
     minr.value.max = FLT_MAX;
     minr.value.min = 1.0f;
+#ifdef KISAK_MP
     bg_fallDamageMinHeight = Dvar_RegisterFloat(
         "bg_fallDamageMinHeight",
         128.0f,
@@ -473,6 +474,22 @@ void __cdecl BG_RegisterDvars()
         mins,
         DVAR_CHEAT | DVAR_TEMP | DVAR_SYSTEMINFO,
         "The height that a player will take maximum damage when falling");
+#elif KISAK_SP
+    bg_fallDamageMinHeight = Dvar_RegisterFloat(
+        "bg_fallDamageMinHeight",
+        200.0f,
+        minr,
+        DVAR_CHEAT | DVAR_TEMP | DVAR_SYSTEMINFO,
+        "The height that a player will start to take minimum damage if they fall");
+    mins.value.max = FLT_MAX;
+    mins.value.min = 1.0f;
+    bg_fallDamageMaxHeight = Dvar_RegisterFloat(
+        "bg_fallDamageMaxHeight",
+        350.0f,
+        mins,
+        DVAR_CHEAT | DVAR_TEMP | DVAR_SYSTEMINFO,
+        "The height that a player will take maximum damage when falling");
+#endif
     mint.value.max = 1000.0f;
     mint.value.min = 0.0f;
     inertiaMax = Dvar_RegisterFloat("inertiaMax", 50.0, mint, DVAR_CHEAT | DVAR_TEMP, "Maximum player inertia");

--- a/src/bgame/bg_weapons.cpp
+++ b/src/bgame/bg_weapons.cpp
@@ -2537,6 +2537,12 @@ int32_t __cdecl PM_Weapon_ShouldBeFiring(pmove_t *pm, int32_t delayedAction)
     iassert(ps);
 
     weapDef = BG_GetWeaponDef(ps->weapon);
+
+#ifdef KISAK_SP
+	if ((ps->weapFlags & 8) != 0)// g_friendlyfireDist
+		return 0;
+#endif
+
     shouldStartFiring = (pm->cmd.buttons & PM_GetWeaponFireButton(ps->weapon)) != 0;
     if (weapDef->freezeMovementWhenFiring && ps->groundEntityNum == ENTITYNUM_NONE)
         shouldStartFiring = 0;

--- a/src/cgame/cg_newdraw.cpp
+++ b/src/cgame/cg_newdraw.cpp
@@ -1187,7 +1187,7 @@ void __cdecl CG_DrawCursorhint(
                                 UI_DrawHandlePic(
                                     &scrPlaceView[localClientNum],
                                     (float)((float)((float)(rect->w *(float)widthScale) + (float)scale) *(float)-0.5),
-                                    (float)((float)((float)height *(float)1.5) + (float)x),
+                                    (float)((float)((float)height *(float)1.5) + (float)y),
                                     (float)((float)(rect->w *(float)widthScale) + (float)scale),
                                     (float)((float)(rect->h *(float)heightScale) + (float)scale),
                                     rect->horzAlign,

--- a/src/game/actor.cpp
+++ b/src/game/actor.cpp
@@ -2113,7 +2113,21 @@ void __cdecl Path_UpdateMovementDelta(actor_s *self, double fMoveDist)
     vWishDir[1] = self->ent->r.currentOrigin[1];
     vWishDir[2] = self->ent->r.currentOrigin[2];
 
+	float vPrevLookaheadDir[3];
+
+	vPrevLookaheadDir[0] = pPath->lookaheadDir[0];
+	vPrevLookaheadDir[1] = pPath->lookaheadDir[1];
+	vPrevLookaheadDir[2] = pPath->lookaheadDir[2];
+
     Path_UpdateLookahead(pPath, vWishDir, Actor_IsDodgeEntity(self, self->Physics.iHitEntnum), 0, 1);
+
+	float pathDirDot = (pPath->lookaheadDir[0] * vPrevLookaheadDir[0]) + (pPath->lookaheadDir[1] * vPrevLookaheadDir[1]);
+	if (pathDirDot < 0.70700002f)
+	{
+		Scr_AddVector(pPath->lookaheadDir);
+		Scr_AddEntity(self->ent);
+		Scr_Notify(self->ent, scr_const.path_changed, 2u);
+	}
 
     perp[0] = pPath->lookaheadDir[0];
     perp[1] = pPath->lookaheadDir[1];

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -380,7 +380,7 @@ const dvar_s *G_RegisterServerDemoDvars()
         "Turn on debug lines for radius damage traces");
     g_useholdtime = Dvar_RegisterInt(
         "g_useholdtime",
-        250,
+        0,
         0,
         0x7FFFFFFF,
         2u,

--- a/src/game/g_scr_main.cpp
+++ b/src/game/g_scr_main.cpp
@@ -2443,6 +2443,20 @@ void __cdecl ScrCmd_LinkTo(scr_entref_t entref)
     LABEL_10:
         v8 = G_EntLinkTo(Entity, v5, ConstLowercaseString);
     }
+    if (v8 && Entity->client)
+    {
+        Entity->client->linkAnglesFrac = 1.0f;
+        Entity->client->linkAnglesLocked = 0;
+        Entity->client->link_rotationMovesEyePos = 0;
+        Entity->client->link_useTagAnglesForViewAngles = 1;
+        Entity->client->link_doCollision = 0;
+        Entity->client->linkAnglesMinClamp[0] = -180.0f;
+        Entity->client->linkAnglesMaxClamp[0] = 180.0f;
+        Entity->client->linkAnglesMinClamp[1] = -180.0f;
+        Entity->client->linkAnglesMaxClamp[1] = 180.0f;
+        Entity->client->ps.pm_flags |= 0x1000000u;
+        Entity->client->prevLinkAnglesSet = 0;
+    }
     if (!v8)
     {
         if (!SV_DObjExists(v5))

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -492,11 +492,12 @@ void __cdecl FireWeapon(gentity_s *ent, int gametime)
     weaponParms wp; // [esp+30h] [ebp-48h] BYREF
     float aimSpreadScale; // [esp+74h] [ebp-4h]
 
-#ifdef KISAK_MP
-	if ((ent->client->ps.eFlags & 0x300) == 0 || !ent->active)
-#elif KISAK_SP
-	if ((ent->client->ps.eFlags & 0x20300) == 0 || !ent->active)
-#endif
+// Optional
+// Prevents AI from taking damage while being shot at.
+//#ifdef KISAK_SP
+//	if ((ent->client->ps.weapFlags & 8) != 0)// g_friendlyfireDist
+//		return;
+//#endif
     {
         Scr_Notify(ent, scr_const.weapon_fired, 0);
         wp.weapDef = BG_GetWeaponDef(ent->s.weapon);

--- a/src/script/scr_compiler2.cpp
+++ b/src/script/scr_compiler2.cpp
@@ -2750,7 +2750,11 @@ void LinkThread(uint32_t threadCountId, VariableValue *pos, bool allowFarCall)
 		}
 
 		*(const char **)value->codePosValue = pos->u.codePosValue;
+		
+		RemoveVariable(threadCountId, i + 2);// free the per-reference position temp
 	}
+
+	RemoveVariable(threadCountId, 0);// free the count temp
 }
 
 /*

--- a/src/script/scr_const.cpp
+++ b/src/script/scr_const.cpp
@@ -401,6 +401,7 @@ void GScr_LoadConsts()
 	scr_const.nogravity = GScr_AllocString("nogravity");
 	scr_const.nophysics = GScr_AllocString("nophysics");
 	scr_const.pain = GScr_AllocString("pain");
+	scr_const.path_changed = GScr_AllocString("path_changed");
 	scr_const.pickup = GScr_AllocString("pickup");
 	scr_const.receiver = GScr_AllocString("receiver");
 	scr_const.run = GScr_AllocString("run");

--- a/src/script/scr_const.h
+++ b/src/script/scr_const.h
@@ -394,6 +394,7 @@ struct scr_const_t
     uint16_t nogravity;
     uint16_t nophysics;
     uint16_t pain;
+	uint16_t path_changed;
     uint16_t pickup;
     uint16_t receiver;
     uint16_t run;

--- a/src/server/sv_ccmds.cpp
+++ b/src/server/sv_ccmds.cpp
@@ -394,7 +394,6 @@ void __cdecl SV_MapRestart(int savegame, int loadScripts)
             if (loadScripts)
             {
                 SV_ClearPendingSaves();
-                SV_AddPendingSave("map_restart", "Start Level Save", "", SAVE_TYPE_AUTOSAVE, 2u, 1);
                 SV_ProcessPendingSaves();
             }
         }


### PR DESCRIPTION
1) [SP] Fixed weapon-pickup cursor-hint icon position (CG_DrawCursorhint used X instead of Y). 2) [SP] Set g_useholdtime default 250 ms -> 0 ms for instant "use" like MP. 3) [SP] Blocked firing while crosshair is over a friendly within g_friendlyfireDist. 4) Split jump_slowdownEnable defaults: enabled (1) in MP, disabled (0) in SP. 5) Split bg_fallDamageMinHeight & bg_fallDamageMaxHeight defaults: 128 & 300 in MP, 200 & 350 in SP. 6) Fixed script variable leak: LinkThread now frees forward-reference temp vars (RemoveVariable). 7) [SP] Added 'path_changed' notifier.
8) [SP] Fixed LinkTo functions: linked ents now inherit the parent tag's angles/orientation.