### PR TITLE
security: harden multiplayer message parsing

### DIFF
--- a/src/client_mp/cl_parse_mp.cpp
+++ b/src/client_mp/cl_parse_mp.cpp
@@ -403,8 +403,20 @@ void __cdecl CL_ParseDownload(int localClientNum, msg_t *msg)
             }
         }
         size = MSG_ReadShort(msg);
+        if (size < 0 || size > (int)sizeof(parseDownloadData))
+        {
+            Com_Error(ERR_DROP, "CL_ParseDownload: invalid download block size %i", size);
+            return;
+        }
         if (size > 0)
+        {
             MSG_ReadData(msg, (uint8_t *)parseDownloadData, size);
+            if (msg->overflowed)
+            {
+                Com_Error(ERR_DROP, "CL_ParseDownload: truncated download block");
+                return;
+            }
+        }
         if (cls.downloadBlock == block)
         {
             if (cls.download)
@@ -486,7 +498,13 @@ void __cdecl CL_ParseServerMessage(int localClientNum, msg_t *msg)
     msgCompressed.cursize = MSG_ReadBitsCompress(
         &msg->data[msg->readcount],
         msgCompressed_buf,
-        msg->cursize - msg->readcount);
+        msg->cursize - msg->readcount,
+        sizeof(msgCompressed_buf));
+    if (msgCompressed.cursize < 0)
+    {
+        Com_Error(ERR_DROP, "Huffman decompression overflow in CL_ParseServerMessage");
+        return;
+    }
 
     while (2)
     {

--- a/src/qcommon/huffman.cpp
+++ b/src/qcommon/huffman.cpp
@@ -14,11 +14,17 @@ int __cdecl get_bit(const uint8_t *fin)
     return t;
 }
 
-void __cdecl Huff_offsetReceive(nodetype *node, int *ch, const uint8_t *fin, int *offset)
+bool __cdecl Huff_offsetReceive(nodetype *node, int *ch, const uint8_t *fin, int *offset, int maxOffset)
 {
     bloc = *offset;
     while (node && node->symbol == 257)
     {
+        if (bloc >= maxOffset)
+        {
+            *ch = 0;
+            *offset = bloc;
+            return false;
+        }
         if (get_bit(fin))
             node = node->right;
         else
@@ -28,11 +34,12 @@ void __cdecl Huff_offsetReceive(nodetype *node, int *ch, const uint8_t *fin, int
     {
         *ch = node->symbol;
         *offset = bloc;
+        return true;
     }
-    else
-    {
-        *ch = 0;
-    }
+
+    *ch = 0;
+    *offset = bloc;
+    return false;
 }
 
 void __cdecl huffman_send(nodetype *node, nodetype *child, uint8_t *fout)

--- a/src/qcommon/huffman.h
+++ b/src/qcommon/huffman.h
@@ -27,7 +27,7 @@ struct huffman_t // sizeof=0x4C14
 };
 
 int __cdecl get_bit(const uint8_t *fin);
-void __cdecl Huff_offsetReceive(nodetype *node, int *ch, const uint8_t *fin, int *offset);
+bool __cdecl Huff_offsetReceive(nodetype *node, int *ch, const uint8_t *fin, int *offset, int maxOffset);
 void __cdecl huffman_send(nodetype *node, nodetype *child, uint8_t *fout);
 void __cdecl add_bit(char bit, uint8_t *fout);
 int __cdecl huffman_bitCountForNode(nodetype *node, nodetype *child);

--- a/src/qcommon/msg_mp.cpp
+++ b/src/qcommon/msg_mp.cpp
@@ -237,24 +237,29 @@ int __cdecl MSG_WriteBitsCompress(bool trainHuffman, const uint8_t *from, uint8_
     return (bit + 7) >> 3;
 }
 
-int __cdecl MSG_ReadBitsCompress(const uint8_t *from, uint8_t *to, int size)
+int __cdecl MSG_ReadBitsCompress(const uint8_t *from, uint8_t *to, int size, int maxSize)
 {
     int bit; // [esp+0h] [ebp-14h] BYREF
-    uint8_t *data; // [esp+4h] [ebp-10h]
     int bits; // [esp+8h] [ebp-Ch]
-    int i; // [esp+Ch] [ebp-8h]
+    int outputSize; // [esp+Ch] [ebp-8h]
     int get; // [esp+10h] [ebp-4h] BYREF
 
+    if (size < 0 || size > 0x0FFFFFFF || maxSize < 0)
+        return -1;
+
     bits = 8 * size;
-    i = 0;
-    data = to;
+    outputSize = 0;
     bit = 0;
     while (bit < bits)
     {
-        Huff_offsetReceive(msgHuff.compressDecompress.tree, &get, from, &bit);
-        *data++ = get;
+        int previousBit = bit;
+        if (!Huff_offsetReceive(msgHuff.compressDecompress.tree, &get, from, &bit, bits))
+            break;
+        if (bit <= previousBit || outputSize >= maxSize)
+            return -1;
+        to[outputSize++] = get;
     }
-    return data - to;
+    return outputSize;
 }
 
 void __cdecl MSG_WriteByte(msg_t *msg, uint8_t c)
@@ -525,6 +530,12 @@ void __cdecl MSG_ReadData(msg_t *msg, uint8_t *data, int len)
 {
     int newcount; // [esp+0h] [ebp-8h]
     signed int cursize; // [esp+4h] [ebp-4h]
+
+    if (len < 0)
+    {
+        msg->overflowed = 1;
+        return;
+    }
 
     newcount = len + msg->readcount;
     if (newcount > msg->cursize)

--- a/src/qcommon/msg_mp.h
+++ b/src/qcommon/msg_mp.h
@@ -96,7 +96,7 @@ int __cdecl MSG_ReadBits(msg_t *msg, uint32_t bits);
 int __cdecl MSG_GetByte(msg_t *msg, int where);
 int __cdecl MSG_ReadBit(msg_t *msg);
 int __cdecl MSG_WriteBitsCompress(bool trainHuffman, const uint8_t *from, uint8_t *to, int size);
-int __cdecl MSG_ReadBitsCompress(const uint8_t *from, uint8_t *to, int size);
+int __cdecl MSG_ReadBitsCompress(const uint8_t *from, uint8_t *to, int size, int maxSize);
 void __cdecl MSG_WriteByte(msg_t *msg, uint8_t c);
 void __cdecl MSG_WriteData(msg_t *buf, uint8_t *data, uint32_t length);
 void __cdecl MSG_WriteShort(msg_t *msg, __int16 c);

--- a/src/server_mp/sv_client_mp.cpp
+++ b/src/server_mp/sv_client_mp.cpp
@@ -299,7 +299,7 @@ void __cdecl SV_ReceiveStats(netadr_t from, msg_t *msg)
     if (ClientByAddress)
     {
         packetNum = MSG_ReadByte(msg);
-        if (packetNum < 8)
+        if (packetNum < 7)
         {
             Com_Printf(15, "Received packet %i of stats data\n", packetNum);
             start = 1240 * packetNum;
@@ -321,6 +321,11 @@ void __cdecl SV_ReceiveStats(netadr_t from, msg_t *msg)
                     v2);
             }
             MSG_ReadData(msg, &ClientByAddress->stats[start], v4);
+            if (msg->overflowed)
+            {
+                Com_PrintWarning(15, "Truncated stat packet %i from client\n", packetNum);
+                return;
+            }
             ClientByAddress->statPacketsReceived |= 1 << packetNum;
             ClientByAddress->lastPacketTime = svs.time;
             v3 = va("statResponse %i", ~ClientByAddress->statPacketsReceived & 0x7F);
@@ -1576,7 +1581,13 @@ void __cdecl SV_ExecuteClientMessage(client_t *cl, msg_t *msg)
     msgCompressed.cursize = MSG_ReadBitsCompress(
         &msg->data[msg->readcount],
         msgCompressed_buf_0,
-        msg->cursize - msg->readcount);
+        msg->cursize - msg->readcount,
+        sizeof(msgCompressed_buf_0));
+    if (msgCompressed.cursize < 0)
+    {
+        SV_DropClient(cl, "SV_ExecuteClientMessage: oversize compressed message", 1);
+        return;
+    }
     if (cl->serverId == sv_serverId_value || cl->downloading || cl->downloadingWWW || cl->clientDownloadingWWW)
     {
         if (SV_ProcessClientCommands(cl, &msgCompressed, 0, &c))

--- a/src/server_mp/sv_main_mp.cpp
+++ b/src/server_mp/sv_main_mp.cpp
@@ -767,7 +767,8 @@ void __cdecl SV_PacketEvent(netadr_t from, msg_t *msg)
                 if (client->messageAcknowledge >= 0)
                 {
                     client->reliableAcknowledge = MSG_ReadLong(msg);
-                    if (client->reliableSequence - client->reliableAcknowledge < 128)
+                    int64_t reliableDelta = (int64_t)client->reliableSequence - client->reliableAcknowledge;
+                    if (reliableDelta >= 0 && reliableDelta < 128)
                     {
                         SV_Netchan_Decode(client, &msg->data[msg->readcount], msg->cursize - msg->readcount);
                         if (client->header.state != 1)


### PR DESCRIPTION
## Summary

This PR hardens several client and server network-message parsing paths against malformed or malicious packets, including vulnerabilities inherited from the old COD4 implementation.

## Changes

- Add input-bit and output-buffer limits to Huffman decompression.
- Reject Huffman output that exceeds the destination buffer on both the client and server.
- Prevent Huffman decoding from reading beyond the compressed input.
- Reject invalid stats packet indices, including the historical type-7 stats packet issue (CVE-2008-2106).
- Reject negative lengths in `MSG_ReadData`.
- Validate reliable acknowledgement deltas using 64-bit arithmetic before processing client messages.
- Reject oversized, negative, and truncated client download blocks.

## Security impact

These changes prevent:

- Out-of-bounds writes while decompressing client messages in `SV_ExecuteClientMessage`.
- Out-of-bounds writes while decompressing server messages in `CL_ParseServerMessage`.
- Negative-length copies in the stats packet handler.
- Server CPU exhaustion from malicious reliable acknowledgement values.
- Client memory corruption from oversized download blocks.

Malformed packets are now rejected before their contents can exceed their associated buffers.