### PR TITLE
Fix/console key

### DIFF
--- a/src/client/cl_console.cpp
+++ b/src/client/cl_console.cpp
@@ -1560,7 +1560,7 @@ const char *__cdecl Con_TokenizeInput()
     cmd = Cmd_Argv(0);
     if (*cmd == 92 || *cmd == 47)
         ++cmd;
-    while (isspace(*cmd))
+    while (isspace((unsigned char)*cmd))
         ++cmd;
     return cmd;
 }
@@ -1569,11 +1569,11 @@ char __cdecl Con_AnySpaceAfterCommand()
 {
     int32_t charIndex; // [esp+0h] [ebp-4h]
 
-    for (charIndex = 0; isspace(g_consoleField.buffer[charIndex]); ++charIndex)
+    for (charIndex = 0; isspace((unsigned char)g_consoleField.buffer[charIndex]); ++charIndex)
         ;
     while (g_consoleField.buffer[charIndex])
     {
-        if (isspace(g_consoleField.buffer[charIndex]))
+        if (isspace((unsigned char)g_consoleField.buffer[charIndex]))
             return 1;
         ++charIndex;
     }
@@ -1592,21 +1592,21 @@ bool __cdecl Con_IsAutoCompleteMatch(const char *query, const char *matchToText,
     if (!con_ignoreMatchPrefixOnly && con_matchPrefixOnly->current.enabled)
         return I_strnicmp(query, matchToText, matchTextLen) == 0;
     matchTextPos = 0;
-    matchLetter = tolower(*matchToText);
+    matchLetter = tolower((unsigned char)*matchToText);
     for (queryPos = query; *queryPos; ++queryPos)
     {
-        if (tolower(*queryPos) == matchLetter)
+        if (tolower((unsigned char)*queryPos) == matchLetter)
         {
             if (++matchTextPos == matchTextLen)
                 return 1;
-            matchLetter = tolower(matchToText[matchTextPos]);
+            matchLetter = tolower((unsigned char)matchToText[matchTextPos]);
         }
         else if (con_matchPrefixOnly->current.enabled)
         {
             if (matchTextPos)
             {
                 matchTextPos = 0;
-                matchLetter = tolower(*matchToText);
+                matchLetter = tolower((unsigned char)*matchToText);
             }
         }
     }
@@ -2747,11 +2747,11 @@ int32_t __cdecl ConDrawInput_TextFieldFirstArgChar()
 {
     int32_t charIndex; // [esp+0h] [ebp-4h]
 
-    for (charIndex = 0; isspace(g_consoleField.buffer[charIndex]); ++charIndex)
+    for (charIndex = 0; isspace((unsigned char)g_consoleField.buffer[charIndex]); ++charIndex)
         ;
-    while (!isspace(g_consoleField.buffer[charIndex]))
+    while (!isspace((unsigned char)g_consoleField.buffer[charIndex]))
         ++charIndex;
-    while (isspace(g_consoleField.buffer[charIndex]))
+    while (isspace((unsigned char)g_consoleField.buffer[charIndex]))
         ++charIndex;
     return charIndex;
 }
@@ -2880,13 +2880,13 @@ int32_t __cdecl Con_GetAutoCompleteColorCodedStringDiscontiguous(
     wasMatching = 0;
     matchTextPos = 0;
     colorCodedPos = 0;
-    matchLetter = tolower(*matchToText);
+    matchLetter = tolower((unsigned char)*matchToText);
     for (queryPos = query; *queryPos; ++queryPos)
     {
-        v4 = tolower(*queryPos);
+        v4 = tolower((unsigned char)*queryPos);
         isMatching = v4 == matchLetter;
         if (v4 == matchLetter)
-            matchLetter = tolower(matchToText[++matchTextPos]);
+            matchLetter = tolower((unsigned char)matchToText[++matchTextPos]);
         if (isMatching != wasMatching)
         {
             wasMatching = isMatching;

--- a/src/client/cl_console.cpp
+++ b/src/client/cl_console.cpp
@@ -343,7 +343,10 @@ void __cdecl Con_Init()
 {
     int32_t i; // [esp+0h] [ebp-4h]
 
-    con_restricted = Dvar_RegisterBool("monkeytoy", 1, DVAR_ARCHIVE, "Restrict console access"); // KISAK: just enable console by default
+    // Was 1, which contradicted the comment: CL_KeyEvent only acts on the console
+    // key when con_restricted is off or the console is already open, so with it on
+    // the console could never be opened.
+    con_restricted = Dvar_RegisterBool("monkeytoy", 0, DVAR_ARCHIVE, "Restrict console access");
     con_matchPrefixOnly = Dvar_RegisterBool(
         "con_matchPrefixOnly",
         1,

--- a/src/client/cl_keys.cpp
+++ b/src/client/cl_keys.cpp
@@ -653,9 +653,9 @@ char __cdecl Field_KeyDownEvent(int32_t localClientNum, const ScreenPlacement *s
                 ++edit->cursor;
             if (isCtrlDown)
             {
-                while (edit->cursor < len && isalnum(edit->buffer[edit->cursor]))
+                while (edit->cursor < len && isalnum((unsigned char)edit->buffer[edit->cursor]))
                     ++edit->cursor;
-                while (edit->cursor < len && !isalnum(edit->buffer[edit->cursor]))
+                while (edit->cursor < len && !isalnum((unsigned char)edit->buffer[edit->cursor]))
                     ++edit->cursor;
             }
             break;
@@ -664,7 +664,7 @@ char __cdecl Field_KeyDownEvent(int32_t localClientNum, const ScreenPlacement *s
                 --edit->cursor;
             if (isCtrlDown)
             {
-                while (edit->cursor > 0 && isalnum(*((char *)&edit->fixedSize + edit->cursor + 3)))
+                while (edit->cursor > 0 && isalnum((unsigned char)*((char *)&edit->fixedSize + edit->cursor + 3)))
                     --edit->cursor;
             }
             if (edit->cursor < edit->scroll)
@@ -973,7 +973,7 @@ void __cdecl ReplaceConsoleInputArgument(int32_t replaceCount, char *replacement
     if (*replacement)
     {
         //for (cmdLineLen = strlen(g_consoleField.buffer); cmdLineLen && isspace(*(char *)(cmdLineLen + 11748111)); --cmdLineLen);
-        for (cmdLineLen = strlen(g_consoleField.buffer); cmdLineLen && isspace(g_consoleField.buffer[cmdLineLen]); --cmdLineLen);
+        for (cmdLineLen = strlen(g_consoleField.buffer); cmdLineLen && isspace((unsigned char)g_consoleField.buffer[cmdLineLen]); --cmdLineLen);
 
         if (replaceCount >= cmdLineLen)
         {
@@ -1059,8 +1059,8 @@ void __cdecl FindMatches(char *s)
             {
                 for (i = 0; s[i]; ++i)
                 {
-                    v1 = tolower(s_shortestMatch[i]);
-                    if (v1 != tolower(s[i]))
+                    v1 = tolower((unsigned char)s_shortestMatch[i]);
+                    if (v1 != tolower((unsigned char)s[i]))
                         break;
                 }
                 v2 = !s[i] || s_hasExactMatch && !s_shortestMatch[i];

--- a/src/client/cl_keys.cpp
+++ b/src/client/cl_keys.cpp
@@ -1457,8 +1457,18 @@ cmd_function_s Key_Bind_f_VAR;
 cmd_function_s Key_Unbind_f_VAR;
 cmd_function_s Key_Unbindall_f_VAR;
 cmd_function_s Key_Bindlist_f_VAR;
+cmd_function_s CL_ToggleConsole_f_VAR;
+
+// The stock config binds the console key to "toggleconsole", which was never
+// registered, so that bind did nothing.
+void __cdecl CL_ToggleConsole_f()
+{
+    Con_ToggleConsole();
+}
+
 void __cdecl CL_InitKeyCommands()
 {
+    Cmd_AddCommandInternal("toggleconsole", CL_ToggleConsole_f, &CL_ToggleConsole_f_VAR);
     Cmd_AddCommandInternal("bind", Key_Bind_f, &Key_Bind_f_VAR);
     Cmd_AddCommandInternal("unbind", Key_Unbind_f, &Key_Unbind_f_VAR);
     Cmd_AddCommandInternal("unbindall", Key_Unbindall_f, &Key_Unbindall_f_VAR);
@@ -1533,7 +1543,10 @@ void __cdecl CL_KeyEvent(int32_t localClientNum, int32_t key, int32_t down, uint
     if (!down || keys[key].repeats <= 1)
     {
     LABEL_38:
-        if ((clientUIActives[0].keyCatchers & 2) == 0 || (clientUIActives[0].keyCatchers & 1) != 0)
+        // Let the console key through while the UI has the keyboard, so it also
+        // opens from the main menu. Inner branches unchanged.
+        if ((clientUIActives[0].keyCatchers & 2) == 0 || (clientUIActives[0].keyCatchers & 1) != 0
+            || CL_IsConsoleKey(key))
         {
             if (!con_restricted->current.enabled || (clientUIActives[0].keyCatchers & 1) != 0)
             {
@@ -1819,7 +1832,10 @@ void __cdecl CL_KeyEvent(int32_t localClientNum, int32_t key, int32_t down, uint
     if (!down || keys[key].repeats <= 1)
     {
     LABEL_38:
-        if ((clientUIActives[0].keyCatchers & 2) == 0 || (clientUIActives[0].keyCatchers & 1) != 0)
+        // Let the console key through while the UI has the keyboard, so it also
+        // opens from the main menu. Inner branches unchanged.
+        if ((clientUIActives[0].keyCatchers & 2) == 0 || (clientUIActives[0].keyCatchers & 1) != 0
+            || CL_IsConsoleKey(key))
         {
             if (!con_restricted->current.enabled || (clientUIActives[0].keyCatchers & 1) != 0)
             {

--- a/src/win32/win_wndproc.cpp
+++ b/src/win32/win_wndproc.cpp
@@ -216,12 +216,19 @@ static uint32_t AdustKeyForNumericKeypad(uint32_t key, uint32_t wParam, uint32_t
 	return !IsNumLockAffectedVK(wParam) ? key : 0;
 }
 
+// Scancode of the key left of '1'. A position, not a character: that key prints
+// grave on US, section on Nordic, caron on Baltic, and is a dead key on several,
+// but it is the console key on all of them.
+#define SCANCODE_CONSOLE 0x29
+
 static unsigned char MapKey(int key, uint32_t wParam)
 {
 	uint32_t result;
 	int i;
 
-	if (((key >> 8) & 0xFF)/*BYTE2*/ == ')')
+	// lParam bits 16-23 are the scancode; this read bits 8-15 (the repeat count),
+	// so it never matched on any layout.
+	if (((key >> 16) & 0xFF) == SCANCODE_CONSOLE)
 		return '~';
 
 	result = 0;


### PR DESCRIPTION
Note this a vibe coded fix. Large comments in code.

Four separate faults sat between the console key and the console, and any one of them alone was enough to stop it opening. All four are fixed here because fixing fewer changes nothing observable.

1. The scancode test read the wrong byte. MapKey already had the layout-independent check and it had never matched on any keyboard, US included:

       if (((key >> 8) & 0xFF)/*BYTE2*/ == ')')
           return '~';

   0x29 -- which the decompiler rendered as ')' -- is the SCANCODE of the key left of '1', and testing it is exactly right: that physical key is the console key whether the layout prints grave, section, caron or one-half there, and it delivers WM_KEYDOWN carrying that scancode even where it is a DEAD key and yields no usable character. But the scancode is in bits 16-23 of lParam and the shift was 8, which reads the high byte of the 16-bit repeat count and is therefore always zero.

2. monkeytoy defaulted to 1. The trailing comment on that line already said "just enable console by default" while the value said the opposite. The gate reads

       if (!con_restricted->current.enabled || (keyCatchers & 1) != 0)

   so with it on, the console key only works while the console is already open -- it can never be opened at all, and fix 1 stays inert. Now 0, which is what the comment always claimed. Still DVAR_ARCHIVE, so a config that saved monkeytoy 1 keeps winning until it is removed or overridden.

3. "toggleconsole" was never registered as a command, although the stock config binds the console key to it -- so the bind route was dead too, and with the built-in check also failing there was no way in at all.

4. The console handling was skipped whenever a menu had the keyboard. The outer condition required KEYCATCH_UI to be clear or the console to be open already, so the console could be opened in game but not from the main menu. Quake makes this key hardcoded precisely so it can never be captured or unbound, and that property was lost in the recovered condition. The key is let through now; the inner branches are untouched, so con_restricted still governs what happens once it is recognised.

Also fixed, because a dead key is what reaches it: a debug CRT assertion, "c >= -1 && c <= 255" in isctype.cpp. Console and edit-field code passes signed char buffer elements straight to isspace/isalnum/tolower, and any byte above 127 is negative there -- exactly what a dead key composes. 19 call sites in cl_console.cpp and cl_keys.cpp now cast to unsigned char. In a release build that is undefined behaviour which happens to work; in a debug build it is an abort dialog on the first such character typed.

Verified in game on an Estonian layout, where neither the built-in key nor a bind to it worked before.