### PR TITLE
refactor: improve initialization of dummy variables for entity / client / playerstate

### DIFF
--- a/src/client_mp/cl_main_mp.cpp
+++ b/src/client_mp/cl_main_mp.cpp
@@ -2732,7 +2732,6 @@ void __cdecl CL_Record_f()
     connstate_t connstate; // [esp+1Ch] [ebp-2B0h]
     uint8_t (*bufData)[131072]; // [esp+20h] [ebp-2ACh]
     char demoName[64]; // [esp+24h] [ebp-2A8h] BYREF
-    entityState_s nullstate; // [esp+64h] [ebp-268h] BYREF
     uint8_t (*compressedBuf)[131072]; // [esp+15Ch] [ebp-170h]
     int32_t localClientNum; // [esp+160h] [ebp-16Ch]
     msg_t buf; // [esp+164h] [ebp-168h] BYREF
@@ -2825,14 +2824,15 @@ void __cdecl CL_Record_f()
                 svsHeader.mapCenter[1] = cls.mapCenter[1];
                 svsHeader.mapCenter[2] = cls.mapCenter[2];
                 memset(&snapInfo, 0, sizeof(snapInfo));
-                memset((uint8_t *)&nullstate, 0, sizeof(nullstate));
                 for (i = 0; i < 1024; ++i)
                 {
                     ent = &LocalClientGlobals->entityBaselines[i];
                     if (ent->number)
                     {
                         MSG_WriteByte(&buf, 3u);
-                        MSG_WriteEntity(&snapInfo, &buf, -90000, &nullstate, ent, 1);
+
+                        static constexpr entityState_s dummy{};
+                        MSG_WriteEntity(&snapInfo, &buf, -90000, &dummy, ent, 1);
                     }
                 }
                 MSG_WriteByte(&buf, 7u);

--- a/src/client_mp/cl_parse_mp.cpp
+++ b/src/client_mp/cl_parse_mp.cpp
@@ -152,7 +152,7 @@ void __cdecl CL_DeltaClient(
     int time,
     clSnapshot_t *frame,
     uint32_t newnum,
-    clientState_s *old,
+    const clientState_s *old,
     int unchanged)
 {
     clientState_s *state; // [esp+8h] [ebp-4h]
@@ -825,7 +825,7 @@ void __cdecl CL_DeltaEntity(
     int time,
     clSnapshot_t *frame,
     uint32_t newnum,
-    entityState_s *old)
+    const entityState_s *old)
 {
     if (!MSG_ReadDeltaEntity(msg, time, old, &cl->parseEntities[cl->parseEntitiesNum & 0x7FF], newnum))
     {
@@ -834,7 +834,7 @@ void __cdecl CL_DeltaEntity(
     }
 }
 
-void __cdecl CL_CopyOldEntity(clientActive_t *cl, clSnapshot_t *frame, entityState_s *old)
+void __cdecl CL_CopyOldEntity(clientActive_t *cl, clSnapshot_t *frame, const entityState_s *old)
 {
     memcpy(
         &cl->parseEntities[cl->parseEntitiesNum++ & 0x7FF],

--- a/src/client_mp/cl_parse_mp.cpp
+++ b/src/client_mp/cl_parse_mp.cpp
@@ -852,7 +852,6 @@ void __cdecl CL_ParsePacketClients(
 {
     clientState_s *oldstate; // [esp+0h] [ebp-80h]
     signed int newnum; // [esp+4h] [ebp-7Ch]
-    clientState_s dummy; // [esp+8h] [ebp-78h] BYREF
     int oldindex; // [esp+78h] [ebp-8h]
     int oldnum; // [esp+7Ch] [ebp-4h]
 
@@ -935,7 +934,8 @@ void __cdecl CL_ParsePacketClients(
             iassert(oldnum > newnum);
             if (cl_shownet->current.integer == 3)
                 Com_Printf(CON_CHANNEL_CLIENT, "%3i:  baseline: %i\n", msg->readcount, newnum);
-            memset(&dummy, 0, sizeof(dummy));
+
+            static constexpr clientState_s dummy{};
             CL_DeltaClient(cl, msg, time, newframe, newnum, &dummy, 0);
         }
     }
@@ -1122,10 +1122,10 @@ void __cdecl CL_ParseGamestate(int localClientNum, msg_t *msg)
                 if (newnum >= MAX_BASELINES)
                     Com_Error(ERR_DROP, "Baseline number out of range: %i", newnum);
 
-                entityState_s nullstate;
-                memset(&nullstate, 0, sizeof(nullstate));
                 entityState_s *to = &cl->entityBaselines[newnum];
-                MSG_ReadDeltaEntity(msg, 0, &nullstate, to, newnum);
+
+                static constexpr entityState_s dummy{};
+                MSG_ReadDeltaEntity(msg, 0, &dummy, to, newnum);
                 break;
             }
 

--- a/src/client_mp/client_mp.h
+++ b/src/client_mp/client_mp.h
@@ -1034,7 +1034,7 @@ void __cdecl CL_DeltaClient(
     int32_t time,
     clSnapshot_t *frame,
     uint32_t newnum,
-    clientState_s *old,
+    const clientState_s *old,
     int32_t unchanged);
 void __cdecl CL_SystemInfoChanged(int32_t localClientNum);
 void __cdecl CL_ParseMapCenter(int32_t localClientNum);
@@ -1052,8 +1052,8 @@ void __cdecl CL_DeltaEntity(
     int32_t time,
     clSnapshot_t *frame,
     uint32_t newnum,
-    entityState_s *old);
-void __cdecl CL_CopyOldEntity(clientActive_t *cl, clSnapshot_t *frame, entityState_s *old);
+    const entityState_s *old);
+void __cdecl CL_CopyOldEntity(clientActive_t *cl, clSnapshot_t *frame, const entityState_s *old);
 void __cdecl CL_ParsePacketClients(
     clientActive_t *cl,
     msg_t *msg,

--- a/src/qcommon/msg_mp.cpp
+++ b/src/qcommon/msg_mp.cpp
@@ -1497,12 +1497,10 @@ int __cdecl MSG_ReadDeltaStruct(
 
 int __cdecl MSG_ReadDeltaClient(msg_t *msg, int time, const clientState_s *from, clientState_s *to, uint32_t number)
 {
-    clientState_s dummy; // [esp+4h] [ebp-70h] BYREF
-
+    static constexpr clientState_s dummy{};
     if (!from)
     {
         from = &dummy;
-        memset((uint8_t *)&dummy, 0, sizeof(dummy));
     }
     return MSG_ReadDeltaStruct(
         msg,
@@ -1610,18 +1608,16 @@ void __cdecl MSG_ReadDeltaPlayerstate(
     playerState_s *to,
     bool predictedFieldsIgnoreXor)
 {
-    int print;
-
-    uint8_t dst[sizeof(playerState_s) + 8]; // [esp+38h] [ebp-2F80h] BYREF
-
+    static constexpr playerState_s dummy{};
     if (!from)
     {
-        from = (playerState_s *)dst;
-        memset(dst, 0, sizeof(playerState_s));
+        from = &dummy;
     }
 
     // Copy entire `from` into `to`
     memcpy(to, from, sizeof(playerState_s));
+
+    int print;
 
     if (cl_shownet && (cl_shownet->current.integer >= 2 || cl_shownet->current.integer == -2))
     {

--- a/src/qcommon/msg_mp.cpp
+++ b/src/qcommon/msg_mp.cpp
@@ -1296,12 +1296,12 @@ double __cdecl MSG_ReadOriginZFloat(msg_t *msg, float oldValue)
     }
 }
 
-int __cdecl MSG_ReadDeltaEntity(msg_t *msg, int time, entityState_s *from, entityState_s *to, uint32_t number)
+int __cdecl MSG_ReadDeltaEntity(msg_t *msg, int time, const entityState_s *from, entityState_s *to, uint32_t number)
 {
-    return MSG_ReadDeltaEntityStruct(msg, time, (char *)from, (char *)to, number);
+    return MSG_ReadDeltaEntityStruct(msg, time, (const char *)from, (char *)to, number);
 }
 
-int __cdecl MSG_ReadDeltaEntityStruct(msg_t *msg, int time, char *from, char *to, uint32_t number)
+int __cdecl MSG_ReadDeltaEntityStruct(msg_t *msg, int time, const char *from, char *to, uint32_t number)
 {
     char *EntityTypeName; // eax
     const NetFieldList *stateFieldList; // [esp+38h] [ebp-20h]
@@ -1407,14 +1407,14 @@ const int numHudElemFields = 40;
 int __cdecl MSG_ReadDeltaArchivedEntity(
     msg_t *msg,
     int time,
-    archivedEntity_s *from,
+    const archivedEntity_s *from,
     archivedEntity_s *to,
     uint32_t number)
 {
     return MSG_ReadDeltaStruct(
         msg,
         time,
-        (char *)from,
+        (const char *)from,
         (char *)to,
         number,
         numArchivedEntityFields,
@@ -1426,7 +1426,7 @@ int __cdecl MSG_ReadDeltaArchivedEntity(
 int __cdecl MSG_ReadDeltaStruct(
     msg_t *msg,
     int time,
-    char *from,
+    const char *from,
     char *to,
     uint32_t number,
     int numFields,
@@ -1490,12 +1490,12 @@ int __cdecl MSG_ReadDeltaStruct(
     }
     else
     {
-        memcpy((uint8_t *)to, (uint8_t *)from, 4 * numFields + 4);
+        memcpy((uint8_t *)to, (const uint8_t *)from, 4 * numFields + 4);
         return 0;
     }
 }
 
-int __cdecl MSG_ReadDeltaClient(msg_t *msg, int time, clientState_s *from, clientState_s *to, uint32_t number)
+int __cdecl MSG_ReadDeltaClient(msg_t *msg, int time, const clientState_s *from, clientState_s *to, uint32_t number)
 {
     clientState_s dummy; // [esp+4h] [ebp-70h] BYREF
 
@@ -1507,7 +1507,7 @@ int __cdecl MSG_ReadDeltaClient(msg_t *msg, int time, clientState_s *from, clien
     return MSG_ReadDeltaStruct(
         msg,
         time,
-        (char *)from,
+        (const char *)from,
         (char *)to,
         number,
         numClientStateFields,

--- a/src/qcommon/msg_mp.h
+++ b/src/qcommon/msg_mp.h
@@ -139,26 +139,26 @@ int __cdecl MSG_ReadDeltaEventParamField(msg_t *msg);
 int __cdecl MSG_Read24BitFlag(msg_t *msg, int oldFlags);
 double __cdecl MSG_ReadOriginFloat(int bits, msg_t *msg, float oldValue);
 double __cdecl MSG_ReadOriginZFloat(msg_t *msg, float oldValue);
-int __cdecl MSG_ReadDeltaEntity(msg_t *msg, int time, entityState_s *from, entityState_s *to, uint32_t number);
-int __cdecl MSG_ReadDeltaEntityStruct(msg_t *msg, int time, char *from, char *to, uint32_t number);
+int __cdecl MSG_ReadDeltaEntity(msg_t *msg, int time, const entityState_s *from, entityState_s *to, uint32_t number);
+int __cdecl MSG_ReadDeltaEntityStruct(msg_t *msg, int time, const char *from, char *to, uint32_t number);
 uint MSG_ReadLastChangedField(msg_t *msg, int totalFields);
 int __cdecl MSG_ReadDeltaArchivedEntity(
     msg_t *msg,
     int time,
-    archivedEntity_s *from,
+    const archivedEntity_s *from,
     archivedEntity_s *to,
     uint32_t number);
 int __cdecl MSG_ReadDeltaStruct(
     msg_t *msg,
     int time,
-    char *from,
+    const char *from,
     char *to,
     uint32_t number,
     int numFields,
     char indexBits,
     const NetField *stateFields,
     int totalFields);
-int __cdecl MSG_ReadDeltaClient(msg_t *msg, int time, clientState_s *from, clientState_s *to, uint32_t number);
+int __cdecl MSG_ReadDeltaClient(msg_t *msg, int time, const clientState_s *from, clientState_s *to, uint32_t number);
 void __cdecl MSG_ReadDeltaPlayerstate(
     int localClientNum,
     msg_t *msg,

--- a/src/qcommon/sv_msg_write_mp.cpp
+++ b/src/qcommon/sv_msg_write_mp.cpp
@@ -2145,14 +2145,14 @@ void __cdecl MSG_WriteDeltaClient(
     const clientState_s *to,
     int force)
 {
-    clientState_s dummy; // [esp+4h] [ebp-70h] BYREF
     int bits; // [esp+70h] [ebp-4h]
 
     iassert( !msg->readOnly );
+
+    static constexpr clientState_s dummy{};
     if (!from)
     {
         from = &dummy;
-        memset((uint8_t *)&dummy, 0, sizeof(dummy));
     }
     if (to)
     {
@@ -2200,7 +2200,6 @@ void __cdecl MSG_WriteDeltaPlayerstate(
     float v13; // [esp+60h] [ebp-2FA4h]
     int lastChangedFieldNum; // [esp+64h] [ebp-2FA0h]
     int v15; // [esp+68h] [ebp-2F9Ch]
-    uint8_t dst[sizeof(playerState_s)]; // [esp+6Ch] [ebp-2F98h] BYREF
     int value; // [esp+2FD8h] [ebp-2Ch]
     int c[4]; // [esp+2FDCh] [ebp-28h]
     int v19; // [esp+2FECh] [ebp-18h]
@@ -2218,10 +2217,11 @@ void __cdecl MSG_WriteDeltaPlayerstate(
     if (sv_debugPacketContents->current.enabled)
         Com_Printf(CON_CHANNEL_SYSTEM, "Writing playerstate for client #%i\n", snapInfo->clientNum);
     snapInfo->packetEntityType = ANALYZE_DATATYPE_ENTITYTYPE_PLAYERSTATE;
+
+    static constexpr playerState_s dummy{};
     if (!from)
     {
-        from = (const playerState_s *)dst;
-        memset(dst, 0, sizeof(playerState_s));
+        from = &dummy;
     }
     if (snapInfo->archived)
     {

--- a/src/qcommon/sv_msg_write_mp.cpp
+++ b/src/qcommon/sv_msg_write_mp.cpp
@@ -1354,7 +1354,7 @@ void __cdecl MSG_WriteEntity(
     SnapshotInfo_s *snapInfo,
     msg_t *msg,
     int time,
-    entityState_s *from,
+    const entityState_s *from,
     const entityState_s *to,
     int force)
 {
@@ -1380,14 +1380,14 @@ void __cdecl MSG_WriteEntity(
             Com_Printf(CON_CHANNEL_SERVER, "Removing entity %i - object is type %i (%s)\n", from->number, from->eType, EntityTypeName);
         }
         snapInfo->packetEntityType = MSG_GetPacketEntityTypeForEType(from->eType);
-        MSG_WriteEntityRemoval(snapInfo, msg, (uint8_t *)from, 10, 0);
+        MSG_WriteEntityRemoval(snapInfo, msg, (const uint8_t *)from, 10, 0);
     }
 }
 
 void __cdecl MSG_WriteEntityRemoval(
     SnapshotInfo_s *snapInfo,
     msg_t *msg,
-    uint8_t *from,
+    const uint8_t *from,
     int indexBits,
     bool changeBit)
 {
@@ -2011,8 +2011,8 @@ void __cdecl MSG_WriteDeltaArchivedEntity(
     SnapshotInfo_s *snapInfo,
     msg_t *msg,
     int time,
-    archivedEntity_s *from,
-    archivedEntity_s *to,
+    const archivedEntity_s *from,
+    const archivedEntity_s *to,
     int force)
 {
     iassert( !msg->readOnly );
@@ -2022,8 +2022,8 @@ void __cdecl MSG_WriteDeltaArchivedEntity(
         snapInfo,
         msg,
         time,
-        (uint8_t *)from,
-        (uint8_t *)to,
+        (const uint8_t *)from,
+        (const uint8_t *)to,
         force,
         69,
         10,
@@ -2035,8 +2035,8 @@ int __cdecl MSG_WriteDeltaStruct(
     SnapshotInfo_s *snapInfo,
     msg_t *msg,
     int time,
-    uint8_t *from,
-    uint8_t *to,
+    const uint8_t *from,
+    const uint8_t *to,
     int force,
     int numFields,
     int indexBits,
@@ -2141,8 +2141,8 @@ void __cdecl MSG_WriteDeltaClient(
     SnapshotInfo_s *snapInfo,
     msg_t *msg,
     int time,
-    clientState_s *from,
-    clientState_s *to,
+    const clientState_s *from,
+    const clientState_s *to,
     int force)
 {
     clientState_s dummy; // [esp+4h] [ebp-70h] BYREF
@@ -2162,8 +2162,8 @@ void __cdecl MSG_WriteDeltaClient(
             snapInfo,
             msg,
             time,
-            (uint8_t *)from,
-            (uint8_t *)to,
+            (const uint8_t *)from,
+            (const uint8_t *)to,
             force,
             24,
             6,
@@ -2178,7 +2178,7 @@ void __cdecl MSG_WriteDeltaClient(
     else
     {
         snapInfo->packetEntityType = ANALYZE_DATATYPE_ENTITYTYPE_CLIENTSTATE;
-        MSG_WriteEntityRemoval(snapInfo, msg, (uint8_t *)from, 6, 1);
+        MSG_WriteEntityRemoval(snapInfo, msg, (const uint8_t *)from, 6, 1);
     }
 }
 
@@ -2569,8 +2569,8 @@ void __cdecl MSG_WriteDeltaFields(
     SnapshotInfo_s *snapInfo,
     msg_t *msg,
     int time,
-    uint8_t *from,
-    uint8_t *to,
+    const uint8_t *from,
+    const uint8_t *to,
     int force,
     int numFields,
     const NetField *stateFields)

--- a/src/qcommon/sv_msg_write_mp.h
+++ b/src/qcommon/sv_msg_write_mp.h
@@ -114,13 +114,13 @@ void __cdecl MSG_WriteEntity(
     SnapshotInfo_s* snapInfo,
     msg_t* msg,
     int time,
-    entityState_s* from,
+    const entityState_s* from,
     const entityState_s* to,
     int force);
 void __cdecl MSG_WriteEntityRemoval(
     SnapshotInfo_s* snapInfo,
     msg_t* msg,
-    uint8_t* from,
+    const uint8_t* from,
     int indexBits,
     bool changeBit);
 void __cdecl MSG_WriteEntityDeltaForEType(
@@ -158,15 +158,15 @@ void __cdecl MSG_WriteDeltaArchivedEntity(
     SnapshotInfo_s* snapInfo,
     msg_t* msg,
     int time,
-    archivedEntity_s* from,
-    archivedEntity_s* to,
+    const archivedEntity_s* from,
+    const archivedEntity_s* to,
     int force);
 int __cdecl MSG_WriteDeltaStruct(
     SnapshotInfo_s* snapInfo,
     msg_t* msg,
     int time,
-    uint8_t* from,
-    uint8_t* to,
+    const uint8_t* from,
+    const uint8_t* to,
     int force,
     int numFields,
     int indexBits,
@@ -176,8 +176,8 @@ void __cdecl MSG_WriteDeltaClient(
     SnapshotInfo_s* snapInfo,
     msg_t* msg,
     int time,
-    clientState_s* from,
-    clientState_s* to,
+    const clientState_s* from,
+    const clientState_s* to,
     int force);
 void __cdecl MSG_WriteDeltaPlayerstate(
     SnapshotInfo_s* snapInfo,
@@ -195,8 +195,8 @@ void __cdecl MSG_WriteDeltaFields(
     SnapshotInfo_s* snapInfo,
     msg_t* msg,
     int time,
-    uint8_t* from,
-    uint8_t* to,
+    const uint8_t* from,
+    const uint8_t* to,
     int force,
     int numFields,
     const NetField* stateFields);

--- a/src/server_mp/sv_client_mp.cpp
+++ b/src/server_mp/sv_client_mp.cpp
@@ -1019,7 +1019,6 @@ uint8_t msgBuffer_0[131072];
 void __cdecl SV_SendClientGameState(client_t *client)
 {
     int configStringCount; // [esp+38h] [ebp-16Ch]
-    entityState_s nullstate; // [esp+3Ch] [ebp-168h] BYREF
     int numWritten; // [esp+138h] [ebp-6Ch]
     int start; // [esp+13Ch] [ebp-68h]
     SnapshotInfo_s snapInfo; // [esp+140h] [ebp-64h] BYREF
@@ -1162,7 +1161,6 @@ void __cdecl SV_SendClientGameState(client_t *client)
             "%s\n\t(clientNum) = %i",
             "(clientNum >= 0 && clientNum < 64)",
             clientNum);
-    memset((uint8_t *)&nullstate, 0, sizeof(nullstate));
     for (start = 0; start < 1024; ++start)
     {
         base = &sv.svEntities[start].baseline.s;
@@ -1174,7 +1172,9 @@ void __cdecl SV_SendClientGameState(client_t *client)
             snapInfo.snapshotDeltaTime = -1;
             snapInfo.fromBaseline = 1;
             snapInfo.packetEntityType = ANALYZE_DATATYPE_ENTITYTYPE_BASELINE;
-            MSG_WriteEntity(&snapInfo, &msg, 0, &nullstate, base, 1);
+
+            static constexpr entityState_s dummy{};
+            MSG_WriteEntity(&snapInfo, &msg, 0, &dummy, base, 1);
             ++numWritten;
             snapInfo.fromBaseline = 0;
         }


### PR DESCRIPTION
This pull request aims to improve the initialization of dummy `entityState` / `clientState` / `playerState` variables, and is split into two commits. First to add `const` to some input / output function parameters. Second to make dummy variables `static constexpr` instead of run-time variables that need be `memset` every time. The second commit relies on the first commit.

Should work but didn't verify.